### PR TITLE
Update com.webos.service.videooutput.role.json.in: Add trustLevel

### DIFF
--- a/files/sysbus/com.webos.service.videooutput.role.json.in
+++ b/files/sysbus/com.webos.service.videooutput.role.json.in
@@ -1,6 +1,7 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/videooutputd",
     "type": "regular",
+    "trustLevel": "oem",
     "allowedNames": ["com.webos.service.videooutput"],
     "permissions": [
         {


### PR DESCRIPTION
Fixes:

Sep 27 07:51:47 qemux86-64 ls-hubd[290]: [] [pmlog] ls-hubd LSHUB_ROLE_FILE {"FILE":"file_parser.cpp","LINE":195} No trust level specified for application in role file (/usr/share/luna-service2/roles.d/com.webos.service.videooutput.role.json)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>