### PR TITLE
com.webos.service.videooutput: Fix outbound permission error

### DIFF
--- a/files/sysbus/com.webos.service.videooutput.perm.json
+++ b/files/sysbus/com.webos.service.videooutput.perm.json
@@ -1,5 +1,5 @@
 {
   "com.webos.service.videooutput": [
-    "settings"
+    "settings.query"
   ]
 }


### PR DESCRIPTION
Fixes:

Apr 12 00:04:29 qemux86-64 SettingsService[1385]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"CLIENT":"com.webos.service.videooutput","SERVICE":"com.webos.service.settings","CATEGORY":"/","METHOD":"getSystemSettings"} Service security groups don't allow method call.

Possibly contributes to YouTube that stopped working in recent releases.